### PR TITLE
add argument name to ArgumentOutOfRangeException

### DIFF
--- a/RectifyLib/Analysis/AnalyserStartupArgs.cs
+++ b/RectifyLib/Analysis/AnalyserStartupArgs.cs
@@ -68,7 +68,7 @@ namespace RectifyLib.Analysis
                 case DateLimits.Year:
                     return dateTaken < _lowerLimit || dateTaken > _upperLimit;
                 default:
-                    throw new ArgumentOutOfRangeException("Unsupported date range for limit filter");
+                    throw new ArgumentOutOfRangeException(nameof(dateTaken), "Unsupported date range for limit filter");
             }
         }
     }


### PR DESCRIPTION
This fixes a Code Analysis rule (CA2208) that isn't enabled by default.
